### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,13 @@
     "ms-token": "^1.2.2",
     "ms-validation": "^3.0.0",
     "mservice": "^4.4.0",
-    "node-uuid": "^1.4.7",
     "password-generator": "^2.0.2",
     "redis-filtered-sort": "^1.3.1",
     "request": "^2.78.0",
     "request-promise": "^4.1.1",
     "scrypt": "^6.0.1",
-    "urlsafe-base64": "^1.0.0"
+    "urlsafe-base64": "^1.0.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "apidoc": "^0.16.1",

--- a/src/utils/checkIpLimits.js
+++ b/src/utils/checkIpLimits.js
@@ -1,6 +1,6 @@
 const { HttpStatusError } = require('common-errors');
 const redisKey = require('./key');
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const handlePipeline = require('../utils/pipelineError.js');
 
 /**


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.