### PR TITLE
feat: add sender info to invitation email

### DIFF
--- a/schemas/organization.invites.send.json
+++ b/schemas/organization.invites.send.json
@@ -2,12 +2,17 @@
   "type": "object",
   "required": [
     "organizationId",
+    "senderId",
     "member"
   ],
   "additionalProperties": false,
   "properties": {
     "organizationId": {
       "type": "string"
+    },
+    "senderId": {
+      "type": "string",
+      "minLength": 1
     },
     "member": {
       "required": [

--- a/schemas/organization.invites.send.json
+++ b/schemas/organization.invites.send.json
@@ -2,7 +2,6 @@
   "type": "object",
   "required": [
     "organizationId",
-    "senderId",
     "member"
   ],
   "additionalProperties": false,

--- a/src/actions/organization/invites/send.js
+++ b/src/actions/organization/invites/send.js
@@ -1,7 +1,10 @@
 const { ActionTransport } = require('@microfleet/core');
 const sendInviteMail = require('../../../utils/organization/send-invite-email');
-const getInternalData = require('../../../utils/organization/get-internal-data');
-const { checkOrganizationExists } = require('../../../utils/organization');
+const {
+  getInternalData,
+  checkOrganizationExists,
+  getOrganizationMemberDisplayName,
+} = require('../../../utils/organization');
 const {
   ORGANIZATIONS_NAME_FIELD,
   ORGANIZATIONS_ID_FIELD,
@@ -24,9 +27,10 @@ const getUserId = require('../../../utils/userData/get-user-id');
  * @apiParam (Payload) {String} member.firstName - member first name.
  * @apiParam (Payload) {String} member.lastName - member last name.
  * @apiParam (Payload) {String[]} member.permissions - member permission list.
+ * @apiParam (Payload) {String} senderId - invitation sender id.
  */
 async function sendOrganizationInvite({ params }) {
-  const { member, organizationId } = params;
+  const { member, organizationId, senderId } = params;
   const organization = await getInternalData.call(this, organizationId);
   let userExist = false;
 
@@ -36,6 +40,8 @@ async function sendOrganizationInvite({ params }) {
   } catch (e) {
     this.log.info('invited user not exist');
   }
+
+  const displayName = await getOrganizationMemberDisplayName.call(this, organizationId, senderId);
 
   return sendInviteMail.call(this, {
     email: member.email,
@@ -47,6 +53,7 @@ async function sendOrganizationInvite({ params }) {
       email: member.email,
       organizationId: organization[ORGANIZATIONS_ID_FIELD],
       organization: organization[ORGANIZATIONS_NAME_FIELD],
+      senderName: displayName,
     },
   }, USERS_ACTION_ORGANIZATION_INVITE);
 }

--- a/src/utils/organization/get-organization-member-display-name.js
+++ b/src/utils/organization/get-organization-member-display-name.js
@@ -1,11 +1,9 @@
-const capitalize = require('lodash/capitalize');
 const { getMemberData } = require('./get-organization-members');
 const { ORGANIZATIONS_MEMBERS } = require('../../constants');
 const redisKey = require('../key');
 
 const buildDisplayName = ({ firstName, lastName, username } = {}) => {
   const displayName = [firstName, lastName]
-    .map(capitalize)
     .join(' ')
     .trim();
 

--- a/src/utils/organization/get-organization-member-display-name.js
+++ b/src/utils/organization/get-organization-member-display-name.js
@@ -11,14 +11,9 @@ const buildDisplayName = ({ firstName, lastName, username } = {}) => {
 };
 
 async function getOrganizationMemberDisplayName(organizationId, userId) {
-  try {
-    const memberKey = redisKey(organizationId, ORGANIZATIONS_MEMBERS, userId);
-    const data = await getMemberData.call(this, memberKey);
+  const memberKey = redisKey(organizationId, ORGANIZATIONS_MEMBERS, userId);
+  const data = await getMemberData.call(this, memberKey);
 
-    return buildDisplayName(data);
-  } catch (e) {
-    this.log.info('unable to get member data');
-  }
-  return null;
+  return buildDisplayName(data);
 }
 module.exports = getOrganizationMemberDisplayName;

--- a/src/utils/organization/get-organization-member-display-name.js
+++ b/src/utils/organization/get-organization-member-display-name.js
@@ -1,0 +1,26 @@
+const capitalize = require('lodash/capitalize');
+const { getMemberData } = require('./get-organization-members');
+const { ORGANIZATIONS_MEMBERS } = require('../../constants');
+const redisKey = require('../key');
+
+const buildDisplayName = ({ firstName, lastName, username } = {}) => {
+  const displayName = [firstName, lastName]
+    .map(capitalize)
+    .join(' ')
+    .trim();
+
+  return displayName || username;
+};
+
+async function getOrganizationMemberDisplayName(organizationId, userId) {
+  try {
+    const memberKey = redisKey(organizationId, ORGANIZATIONS_MEMBERS, userId);
+    const data = await getMemberData.call(this, memberKey);
+
+    return buildDisplayName(data);
+  } catch (e) {
+    this.log.info('unable to get member data');
+  }
+  return null;
+}
+module.exports = getOrganizationMemberDisplayName;

--- a/src/utils/organization/index.js
+++ b/src/utils/organization/index.js
@@ -3,6 +3,7 @@ const resolveOrganizationData = require('./resolve-organization-data');
 const getInternalData = require('./get-internal-data');
 const getOrganizationMetadataAndMembers = require('./get-organization-metadata-and-members');
 const getOrganizationMembers = require('./get-organization-members');
+const getOrganizationMemberDisplayName = require('./get-organization-member-display-name');
 const getOrganizationMetadata = require('./get-organization-metadata');
 const checkOrganizationExists = require('./check-organization-exists');
 
@@ -12,6 +13,7 @@ module.exports = {
   getInternalData,
   getOrganizationMetadataAndMembers,
   getOrganizationMembers,
+  getOrganizationMemberDisplayName,
   getOrganizationMetadata,
   checkOrganizationExists,
 };

--- a/test/suites/actions/organization/invites.js
+++ b/test/suites/actions/organization/invites.js
@@ -65,6 +65,16 @@ describe('#invite organization', function registerSuite() {
     assert.strictEqual(this.spy.lastCall.args[3].senderName, expectedName);
   });
 
+  it('returns empty for unknown sender', async function test() {
+    const opts = {
+      organizationId: this.organization.id,
+      senderId: 'unknown-sender-id',
+      member: this.member,
+    };
+    await this.dispatch('users.organization.invites.send', opts);
+    assert.strictEqual(this.spy.lastCall.args[3].senderName, undefined);
+  });
+
   it('must be able to resend invite to member', async function test() {
     const opts = {
       organizationId: this.organization.id,


### PR DESCRIPTION
Based on the "Update invitation email template" feature request (slw-171)
In the gRPC proxy `senderId` should be assigned automatically just like the `organizationId`
Consider to use `senderId` as optional param instead of required in `organization.invites.send` schema
