### PR TITLE
fix: redis parameter name validation

### DIFF
--- a/src/utils/redis-search-stack/build-search-query.js
+++ b/src/utils/redis-search-stack/build-search-query.js
@@ -35,7 +35,7 @@ const buildTokensQuery = ({ partialMatch = false, suffix = '' } = {}) => (field,
 
   const params = [];
   const paramRefs = [];
-  const args = suffix.length ? [FIELD_PREFIX, propName, suffix] : [FIELD_PREFIX, propName];
+  const args = suffix.length ? [FIELD_PREFIX, normalizePropName(propName), suffix] : [FIELD_PREFIX, propName];
 
   for (const [idx, token] of tokens.entries()) {
     const pName = buildParamName(...args, String(idx + 1));

--- a/src/utils/redis-search-stack/build-search-query.js
+++ b/src/utils/redis-search-stack/build-search-query.js
@@ -30,6 +30,11 @@ const buildStringQuery = (field, propName, value) => {
   return [query, params];
 };
 
+const PARTIAL_MATCH_PARAMS_OPTIONS = {
+  partialMatch: true,
+  suffix: ParamSuffix.match,
+};
+
 const buildTokensQuery = ({ partialMatch = false, suffix = '' } = {}) => (field, propName, value) => {
   const tokens = tokenize(value);
 
@@ -50,14 +55,7 @@ const buildTokensQuery = ({ partialMatch = false, suffix = '' } = {}) => (field,
   return [query, flatten(params)];
 };
 
-const buildMultiTokenMatch = (field, prop, value) => {
-  const options = {
-    partialMatch: true,
-    suffix: ParamSuffix.match,
-  };
-
-  return buildTokensQuery(options)(field, prop, value);
-};
+const buildMultiTokenMatch = (field, prop, value) => buildTokensQuery(PARTIAL_MATCH_PARAMS_OPTIONS)(field, prop, value);
 
 const searchQueryBuilder = {
   // (prop, field, expr)

--- a/test/configs/redis-indexes.js
+++ b/test/configs/redis-indexes.js
@@ -15,7 +15,7 @@ exports.redisIndexDefinitions = [
       ['firstName', 'TEXT', 'NOSTEM', 'SORTABLE'],
       ['lastName', 'TEXT', 'NOSTEM', 'SORTABLE'],
     ],
-    multiWords: ['username'],
+    multiWords: ['username', 'firstName', 'lastName'],
   },
   // Index Name: {ms-users}-test-api-idx
   // Index Filter: test!api

--- a/test/suites/actions/list-search.js
+++ b/test/suites/actions/list-search.js
@@ -42,11 +42,12 @@ const saveUser = (redis, category, audience, user) => redis
   )
   .exec();
 
-function listRequest(filter, criteria = 'username') {
+function listRequest(filter, criteria = 'username', order = 'ASC') {
   return this.users
     .dispatch('list', {
       params: {
         criteria,
+        order,
         audience: this.audience,
         filter,
       },
@@ -231,7 +232,7 @@ describe('Redis Search: list', function listSuite() {
       });
   });
 
-  it('list with #multi fields (partial search)', function test() {
+  it('list with #multi fields, partial search, DESC order', function test() {
     return this
       .filteredListRequest({
         '#multi': {
@@ -241,7 +242,7 @@ describe('Redis Search: list', function listSuite() {
           ],
           match: 'Joh', // hny
         },
-      })
+      }, 'username', 'DESC')
       .then((result) => {
         assert(result);
         expect(result.users).to.have.length.gte(2);
@@ -250,8 +251,8 @@ describe('Redis Search: list', function listSuite() {
         sortByCaseInsensitive(this.extractUserName)(copy);
 
         const [u1, u2] = copy;
-        expect(this.extractUserName(u1)).to.be.equal('johnny@gmail.org');
-        expect(this.extractUserName(u2)).to.be.equal('kim@yahoo.org');
+        expect(this.extractUserName(u1)).to.be.equal('kim@yahoo.org');
+        expect(this.extractUserName(u2)).to.be.equal('johnny@gmail.org');
       });
   });
 

--- a/test/suites/actions/list-search.js
+++ b/test/suites/actions/list-search.js
@@ -232,7 +232,9 @@ describe('Redis Search: list', function listSuite() {
       });
   });
 
-  it('list with #multi fields, partial search, DESC order', function test() {
+  it('list with #multi fields, tokens, partial search, DESC order', function test() {
+    // @firstName|lastName:($f_firstName_lastName_m_1*) PARAMS 2 f_firstName_lastName_m_1 Joh
+    // DIALECT 2 SORTBY username DESC LIMIT 0 10 NOCONTENT
     return this
       .filteredListRequest({
         '#multi': {


### PR DESCRIPTION
Parser error:
```
,"err":{"type":"ReplyError","message":"No such parameter `f_username`","stack":"ReplyError
 : No such parameter `f_username`\n at parseError (/src/node_modules/.pnpm/redis-parser@3.0.0/nod
 e_modules/redis-parser/lib/parser.js)
 ```

Bad name: 
`@n|m:($f_n|m_1*) PARAMS 2 f_n|m_1`

Good name after fix:
`@n|m:($f_n_m_1*) PARAMS 2 f_n_m_1`